### PR TITLE
Update README with improved configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 This repository contains the shared Renovate configuration used across iloc-inc projects.
 
+## Available Configurations
+
+- `default.json` - Base configuration for all projects
+- `go.json` - Go/Golang specific settings
+- `hugo.json` - Hugo static site generator settings
+- `terraform.json` - Terraform project settings (AWS providers, modules, toolchain)
+
 ## Usage
+
+### Default Configuration
 
 In your repository, add `.github/renovate.json` with:
 
@@ -10,6 +19,37 @@ In your repository, add `.github/renovate.json` with:
 {
   "extends": [
     "github>iloc-inc/renovate-config"
+  ]
+}
+```
+
+### Specialized Configurations
+
+For specific project types, use the appropriate configuration:
+
+#### Terraform Projects (including security-infra)
+```json
+{
+  "extends": [
+    "github>iloc-inc/renovate-config:terraform"
+  ]
+}
+```
+
+#### Go Projects
+```json
+{
+  "extends": [
+    "github>iloc-inc/renovate-config:go"
+  ]
+}
+```
+
+#### Hugo Projects
+```json
+{
+  "extends": [
+    "github>iloc-inc/renovate-config:hugo"
   ]
 }
 ```


### PR DESCRIPTION
## Summary
- Enhance README with comprehensive configuration documentation
- Standardize on `.github/renovate.json` location per iloc convention
- Document all available configuration presets and their usage

## Changes
### Documentation Improvements
- **Add** complete list of available configurations with descriptions
- **Specify** standard `.github/renovate.json` location (matches existing iloc projects)
- **Document** terraform config usage for security-infra and infrastructure projects
- **Include** usage examples for all specialized configurations (go, hugo, terraform)

### Configuration Clarifications
- **Terraform preset**: Suitable for security-infra and general terraform projects
- **Location standard**: `.github/renovate.json` (consistent with company-site, martify)
- **Preset inheritance**: Clear examples for each project type

## Context
This updates documentation to reflect:
1. Addition of security-infra to use terraform preset
2. Standard file location used across iloc projects
3. Better organization of available configuration options

## Test Plan
- [ ] Verify all referenced configuration files exist
- [ ] Confirm examples match actual preset contents
- [ ] Validate markdown formatting and links

🤖 Generated with [Claude Code](https://claude.ai/code)