### PR TITLE
docs: README.mdに設定詳細と使用例を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,30 @@
 
 共有 Renovate 設定 - 依存関係自動更新 (Go/Terraform/Hugo)
 
+## 概要
+
+iloc全体での統一された依存関係更新管理を提供する共有Renovate設定システムです。
+
+**📋 戦略・運用ガイド**: [`../company-ai-strategy/renovate.md`](../company-ai-strategy/renovate.md) で詳細な運用情報を確認
+
 ## 🚀 開発コマンド
 
-このリポジトリは設定ファイルのみのため、特別な開発コマンドはありません。
+設定ファイル専用リポジトリのため、特別な開発コマンドはありません。
 
 設定変更後は他リポジトリでの動作確認を行います。
 
-## Available Configurations
+## 設定ファイル
 
-- `default.json` - Base configuration for all projects
-- `go.json` - Go/Golang specific settings
-- `hugo.json` - Hugo static site generator settings
-- `terraform.json` - Terraform project settings (AWS providers, modules, toolchain)
+- **`default.json`**: 全プロジェクト共通設定（Asia/Tokyoタイムゾーン、平日朝8時前スケジュール）
+- **`go.json`**: Go専用設定（.go-version、go.mod、golangci-lint管理）
+- **`hugo.json`**: Hugo専用設定（Netlify/GitHub Actions版本管理）
+- **`terraform.json`**: Terraform専用設定（AWS provider、バージョン制約管理）
 
-## Usage
+## 使用方法
 
-### Default Configuration
+### 基本設定
 
-In your repository, add `.github/renovate.json` with:
+各リポジトリで `.github/renovate.json` を作成：
 
 ```json
 {
@@ -29,11 +35,9 @@ In your repository, add `.github/renovate.json` with:
 }
 ```
 
-### Specialized Configurations
+### 技術別設定
 
-For specific project types, use the appropriate configuration:
-
-#### Terraform Projects (including security-infra)
+#### Terraformプロジェクト
 ```json
 {
   "extends": [
@@ -42,7 +46,7 @@ For specific project types, use the appropriate configuration:
 }
 ```
 
-#### Go Projects
+#### Goプロジェクト
 ```json
 {
   "extends": [
@@ -51,7 +55,7 @@ For specific project types, use the appropriate configuration:
 }
 ```
 
-#### Hugo Projects
+#### Hugoプロジェクト
 ```json
 {
   "extends": [
@@ -59,3 +63,21 @@ For specific project types, use the appropriate configuration:
   ]
 }
 ```
+
+### 組み合わせ使用
+
+```json
+{
+  "extends": [
+    "github>iloc-inc/renovate-config:default",
+    "github>iloc-inc/renovate-config:terraform"
+  ]
+}
+```
+
+## 主な機能
+
+- **自動スケジューリング**: 平日朝8時前（Asia/Tokyo）にPR作成
+- **自動マージ**: パッチ更新・Go依存関係・AWS SDK更新
+- **手動レビュー**: メジャーバージョン・Terraform・Hugo更新
+- **グループ化**: 関連パッケージをまとめて更新


### PR DESCRIPTION
## Summary  
- renovate-config/README.mdを拡充して実用性向上
- company-ai-strategy/renovate.mdとの相互リンク追加
- 設定詳細と使用方法の日本語対応
- 62行から84行に拡張（実用情報を追加）

## Changes
- **概要**: 相互リンクで適切な情報分離
- **設定ファイル**: 各設定の詳細説明追加  
- **使用方法**: 組み合わせ使用例追加
- **機能説明**: 自動化戦略の要約追加

## Information Architecture
- **renovate-config/README.md**: 具体的な設定手順・使用方法
- **company-ai-strategy/renovate.md**: 概要・戦略・運用ガイド

両ドキュメントが相互リンクで適切に連携する構造を実現。

🤖 Generated with [Claude Code](https://claude.ai/code)