### PR TITLE
fix: README.mdに戦略・運用ガイドへのバックリンクを復元

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 iloc全体での統一された依存関係更新管理を提供する共有Renovate設定システムです。
 
+**📋 戦略・運用ガイド**: [`../company-ai-strategy/renovate.md`](../company-ai-strategy/renovate.md) で詳細な運用情報を確認
+
 ## 🚀 開発コマンド
 
 設定ファイル専用リポジトリのため、特別な開発コマンドはありません。


### PR DESCRIPTION
## Summary
- renovate-config/README.mdにcompany-ai-strategy/renovate.mdへのバックリンクを復元
- 運用戦略・ガバナンス情報への適切な参照を提供
- 相互参照による情報アクセス性向上

## Problem Fixed
renovate-configリポジトリのREADME.mdから戦略・運用ガイドへのリンクが削除されていた問題を修正。

## Information Architecture
- **renovate-config/README.md**: 具体的な設定手順・使用方法
- **company-ai-strategy/renovate.md**: 概要・戦略・運用ガイド

開発者が設定詳細から運用戦略へ、または戦略から具体的設定へスムーズに移動可能。

🤖 Generated with [Claude Code](https://claude.ai/code)