### PR TITLE
Goランタイムバージョン更新の統合設定

### DIFF
--- a/go.json
+++ b/go.json
@@ -53,6 +53,12 @@
       "matchManagers": ["regex"],
       "matchPackageNames": ["golangci/golangci-lint"],
       "groupName": "golangci-lint dependencies"
+    },
+    {
+      "matchManagers": ["regex", "dockerfile"],
+      "matchPackageNames": ["go", "golang"],
+      "groupName": "Go runtime versions",
+      "groupSlug": "go-runtime"
     }
   ]
 }


### PR DESCRIPTION
## 概要
DockerのGolangイメージとgo.modのGoランタイムバージョン更新を単一のPRに統合する設定を追加。

## 背景
現在、Goバージョン更新（1.25.0 → 1.25.1等）が以下のように分離されている：
- PR1: `Dockerfile` の `FROM golang:1.25.0-alpine3.22` 更新
- PR2: `go.mod` の `go 1.25.0`, `toolchain go1.25.0` 更新

## 変更内容
### renovate-config/go.json
新しいPackageRuleを追加：
```json
{
  "matchManagers": ["regex", "dockerfile"],
  "matchPackageNames": ["go", "golang"], 
  "groupName": "Go runtime versions",
  "groupSlug": "go-runtime"
}
```

## 期待される効果
### 統合対象
- **go.mod**: `go 1.25.0` → `go 1.25.1`
- **go.mod**: `toolchain go1.25.0` → `toolchain go1.25.1`  
- **Dockerfile**: `golang:1.25.0-alpine3.22` → `golang:1.25.1-alpine3.22`

### メリット
- **レビュー効率**: 関連する更新を一括確認
- **テスト効率**: Go環境の統一的な動作確認
- **デプロイ効率**: 環境間での一貫性保証

### 対象プロジェクト
- `martify` - Go + Docker構成
- その他のGo + Docker利用プロジェクト

## 適用タイミング
このPRマージ後の次回Renovate実行（平日朝8時前）から有効。

🤖 Generated with [Claude Code](https://claude.ai/code)