### PR TITLE
TFLintバージョンの自動検出をcustomManagersで追加

### DIFF
--- a/terraform.json
+++ b/terraform.json
@@ -1,5 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "description": "GitHub Actionsワークフロー内のtflint_versionを検出",
+      "customType": "regex",
+      "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": ["tflint_version:\\s*(?<currentValue>v\\S+)"],
+      "depNameTemplate": "terraform-linters/tflint",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "packageRules": [
     {
       "description": "Terraform providers: 手動。PRはまとめる。新着直後はPR作成を遅らせる＋lockfile更新",


### PR DESCRIPTION
## Summary
- `terraform.json`に`customManagers`を追加し、GitHub Actionsワークフロー内の`tflint_version`パラメータをRenovateが自動検出できるようにした
- `terraform-linters/setup-tflint`アクションの`tflint_version`が対象
- データソースは`github-releases`（`terraform-linters/tflint`）を使用

## 背景
- iloc-inc/security-infra#130 で、Renovateが`tflint_version`を検出できず自動更新PRが作成されないことが判明
- `tflint_version`はGitHub Actionsの`with`パラメータとして設定されており、Renovateの標準マネージャーでは検出されない
- `customManagers`（regex型）でパターンマッチングすることで解決

## 設定内容
```json
"customManagers": [
  {
    "customType": "regex",
    "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
    "matchStrings": ["tflint_version:\\s*(?<currentValue>v\\S+)"],
    "depNameTemplate": "terraform-linters/tflint",
    "datasourceTemplate": "github-releases"
  }
]
```

## 影響範囲
- `github>iloc-inc/renovate-config:terraform`をextendsしている全リポジトリに適用される
- 現在対象: security-infra

## Test plan
- [ ] JSONバリデーション通過済み（`jq .`）
- [ ] マージ後、次回Renovate実行時にsecurity-infraでtflint更新PRが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)