### PR TITLE
Dependency Dashboardを有効化

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,8 +4,7 @@
   "timezone": "Asia/Tokyo",
   "schedule": ["before 8am on weekday"],
   "labels": ["dependencies"],
-  "dependencyDashboard": false,
-  "dependencyDashboardApproval": false,
+  "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- `dependencyDashboard`を`true`に変更
- `dependencyDashboardApproval`はデフォルト`false`のため削除（不要な設定）

## 背景
- Mendポータルで毎回手動「Create」が必要だった問題を解消
- Dashboard有効化により、各リポジトリにDependency Dashboard issueが自動作成される
- issueのチェックボックスから手動トリガーやPR管理が可能になる

## 影響範囲
- `github>iloc-inc/renovate-config:default`をextendsしている全リポジトリに適用

## Test plan
- [ ] マージ後、各リポジトリに「Dependency Dashboard」issueが作成されることを確認
- [ ] Renovateがスケジュール通りに自動実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)