### PR TITLE
サプライチェーン攻撃対策を追加（Digest Pinning + 脆弱性アラート）

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,11 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "timezone": "Asia/Tokyo",
   "schedule": ["before 8am on weekday"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
+  "pinDigests": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
   "packageRules": [
     {
       "matchPackagePatterns": ["^@?aws-sdk", "^github\\.com/aws/aws-sdk-go-v2"],


### PR DESCRIPTION
## Summary
- `pinDigests: true` で全依存関係をSHA256ハッシュで固定（タグ上書き攻撃を防御）
- `helpers:pinGitHubActionDigests` でGitHub Actionsのdigest pinningを有効化
- `vulnerabilityAlerts` で脆弱性検出時に`security`ラベル付きPRを自動作成

## 適用範囲
`default.json`への変更なので、iloc全プロジェクト（martify, infra, security-infra, company-site）に自動適用されます。

## 反映後の動作
- Renovateが次回実行時に、既存の依存関係をdigest付きに変換するPRを各リポジトリに作成します
- 以降の更新PRでもハッシュ + コメントでバージョン表示される形式になります

## Test plan
- [ ] Renovate Dashboardで設定が正しく読み込まれることを確認
- [ ] 各リポジトリでdigest pinning PRが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)