### PR TITLE
Dependency DashboardのPR自動作成を有効化

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
   "schedule": ["before 8am on weekday"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,
+  "dependencyDashboardApproval": false,
   "semanticCommits": "enabled",
   "pinDigests": true,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
- `dependencyDashboardApproval: false` を明示的に設定
- これまでMend.io Dashboard上で手動クリックしないとPRが作成されなかった問題を解消
- スケジュール（平日朝8時前）通りにPRが自動作成されるようになる

## 適用範囲
全プロジェクト（martify, infra, security-infra, company-site）に自動適用

## Test plan
- [ ] 次回Renovate実行時にDashboardクリック不要でPRが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)