### PR TITLE
go.jsonとterraform.jsonからautomergeを完全削除

### DIFF
--- a/go.json
+++ b/go.json
@@ -45,9 +45,7 @@
     },
     {
       "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": true,
-      "automergeType": "pr"
+      "matchUpdateTypes": ["patch"]
     },
     {
       "matchManagers": ["regex"],

--- a/terraform.json
+++ b/terraform.json
@@ -31,9 +31,7 @@
       "groupName": "aws provider (patch)",
       "labels": ["terraform", "provider", "aws"],
       "postUpdateOptions": ["terraformLockFile"],
-      "rangeStrategy": "bump",
-      "automerge": true,
-      "automergeType": "pr"
+      "rangeStrategy": "bump"
     },
     {
       "description": "Terraform modules は手動（挙動差リスク大）",
@@ -58,9 +56,7 @@
       "matchManagers": ["terraform-version"],
       "groupName": "terraform toolchain",
       "labels": ["terraform", "toolchain"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": true,
-      "automergeType": "pr"
+      "matchUpdateTypes": ["patch"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `go.json`: Goパッチ更新の`automerge: true`を削除
- `terraform.json`: AWS providerパッチとterraform toolchainパッチの`automerge: true`を削除
- `default.json`の`automerge: false`がpackageRulesで上書きされていたのが原因

## 変更後
全ての依存関係更新PRは手動レビュー・マージ必須になります。

## Test plan
- [ ] Renovate PRが自動マージされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)