### PR TITLE
Renovateスケジュール窓を拡大（金曜19時以降）

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["after 7pm and before 9pm on friday"],
+  "schedule": ["after 7pm on friday"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "dependencyDashboardApproval": false,


### PR DESCRIPTION
## Summary
- Renovateのスケジュールを `after 7pm and before 9pm on friday` → `after 7pm on friday` に変更
- リポジトリ増加（go-common, edinet-feeder追加）により2時間窓では全リポジトリ処理しきれず、PR未作成になるケースが発生していた
- 上限撤廃により金曜19時以降に余裕を持って全リポジトリを処理可能に

## Test plan
- [ ] マージ後、次回金曜にgo-common/edinet-feederでもPRが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)