### PR TITLE
go-commonの自動バージョン更新を設定

### DIFF
--- a/go.json
+++ b/go.json
@@ -38,9 +38,19 @@
     }
   ],
 
+  "postUpdateOptions": ["gomodTidy"],
+
   "packageRules": [
     {
       "matchManagers": ["gomod"],
+      "matchPackagePatterns": ["^github\\.com/iloc-inc/go-common"],
+      "groupName": "go-common",
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "excludePackagePatterns": ["^github\\.com/iloc-inc/go-common"],
       "groupName": "Go dependencies"
     },
     {


### PR DESCRIPTION
## Summary
- `go-common` (`github.com/iloc-inc/go-common`) の更新を独立したPRとして作成するpackageRuleを追加
- `postUpdateOptions: ["gomodTidy"]` を追加し、`go.sum` の自動更新に対応
- 他のGo依存は既存の「Go dependencies」グループに引き続きまとめられる

## 対象リポジトリ
この共有設定を参照する以下のリポジトリに適用されます：
- `iloc-inc/martify`
- `iloc-inc/edinet-feeder`

## 注意事項
- Renovate GitHub Appが `iloc-inc/go-common` リポジトリにアクセスできることを確認してください
  - GitHub > Organization Settings > Installed GitHub Apps > Renovate > Repository access

## Test plan
- [ ] Renovate Appが`go-common`リポジトリにアクセス可能か確認
- [ ] martifyのDependency Dashboardで`go-common`が検出されることを確認
- [ ] edinet-feederのDependency Dashboardで`go-common`が検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)