### PR TITLE
Goバージョン自動更新が動作しない問題を修正

### DIFF
--- a/go.json
+++ b/go.json
@@ -3,24 +3,27 @@
 
   "regexManagers": [
     {
-      "fileMatch": ["^\\.go-version$"],
+      "fileMatch": ["(^|/)\\.go-version$"],
       "matchStrings": ["^(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)$"],
       "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
       "versioningTemplate": "semver"
     },
     {
-      "fileMatch": ["^go\\.mod$"],
+      "fileMatch": ["(^|/)go\\.mod$"],
       "matchStrings": [
         "(?m)^go (?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)$",
         "(?m)^toolchain go(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)$"
       ],
       "depNameTemplate": "go",
-      "versioningTemplate": "golang"
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
     },
     {
-      "fileMatch": ["^go\\.work$"],
+      "fileMatch": ["(^|/)go\\.work$"],
       "matchStrings": ["(?m)^toolchain go(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)$"],
       "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
       "versioningTemplate": "semver"
     },
     {


### PR DESCRIPTION
## Summary
- `regexManagers` の `.go-version`・`go.mod`・`go.work` ルールに `datasourceTemplate: "golang-version"` を追加
- `fileMatch` パターンをサブディレクトリ対応に変更（`^go\.mod$` → `(^|/)go\.mod$` 等）
- `go.mod` の `versioningTemplate` を `"golang"` → `"semver"` に統一

## Background
go-common, martify, edinet-feeder の3リポジトリでGoバージョンが1.25のまま更新されていなかった。原因は `datasourceTemplate` 未指定により、Renovateが新バージョンの取得先を認識できずPRが生成されなかったため。kabu-station-feederのみ手動で1.26.2に更新済みだった。

## Test plan
- [ ] マージ後、次回Renovate実行時にGo 1.26.x への更新PRが各リポジトリに作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)