### PR TITLE
fix: .go-versionとgo.modのGoバージョン更新を同一PRにグルーピング

### DIFF
--- a/go.json
+++ b/go.json
@@ -45,6 +45,11 @@
 
   "packageRules": [
     {
+      "matchDepNames": ["go"],
+      "matchDatasources": ["golang-version"],
+      "groupName": "go version"
+    },
+    {
       "matchManagers": ["gomod"],
       "matchPackagePatterns": ["^github\\.com/iloc-inc/go-common"],
       "groupName": "go-common",


### PR DESCRIPTION
## Summary

- Goバージョン更新時に `go.mod` のみ更新され `.go-version` が含まれないためCIが落ちる問題を修正
- `matchDepNames: ["go"]` + `matchDatasources: ["golang-version"]` でregex/gomodマネージャー横断のグルーピングを追加

## 背景

Renovateの `gomod` マネージャーが `go.mod` の `go` ディレクティブを更新し、`regex` マネージャーが `.go-version` を更新するが、別PRになっていた。CIは `.go-version` からGoバージョンを読むため、不整合でビルドが失敗する。

影響を受けたPR:
- iloc-inc/jpx-feeder#3
- iloc-inc/kabu-station-feeder#18
- iloc-inc/martify#535

🤖 Generated with [Claude Code](https://claude.com/claude-code)