### PR TITLE
fix: Goプライベートモジュールの認証をhostRulesで設定

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,6 +13,12 @@
     "enabled": true,
     "labels": ["security"]
   },
+  "hostRules": [
+    {
+      "matchHost": "github.com",
+      "hostType": "go"
+    }
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": ["^@?aws-sdk", "^github\.com/aws/aws-sdk-go-v2"],


### PR DESCRIPTION
## Summary

- `hostRules` で github.com を Go モジュールホストとして設定
- Renovate が `go mod tidy` 実行時にプライベートモジュール（`github.com/iloc-inc/*`）を取得可能に

## 背景

`postUpdateOptions: ["gomodTidy"]` が設定されているが、Renovate の実行環境（Mend クラウド）から `iloc-inc` のプライベートモジュールにアクセスできず、`go.sum` が不完全な状態でPRが作成されていた。

影響を受けたPR:
- iloc-inc/jpx-feeder#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)