### PR TITLE
fix: default.jsonの不正なJSONエスケープを修正

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,7 +21,7 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": ["^@?aws-sdk", "^github\.com/aws/aws-sdk-go-v2"],
+      "matchPackagePatterns": ["^@?aws-sdk", "^github\\.com/aws/aws-sdk-go-v2"],
       "groupName": "aws-sdk packages"
     }
   ]


### PR DESCRIPTION
## Summary

- `matchPackagePatterns` の正規表現 `^github\.com` → `^github\\.com` に修正
- JSONとして不正な `\.` エスケープが原因でJSON5フォールバックされていた

## 背景

全リポジトリのRenovateダッシュボードで以下の警告が出ていた:

> ⚠️ File contents are invalid JSONC but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)