### PR TITLE
Renovateのスケジュールを毎日実行に変更

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["after 7pm on friday"],
+  "schedule": ["after 7pm every day"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "dependencyDashboardApproval": false,


### PR DESCRIPTION
## Summary
- Renovateの実行スケジュールを `after 7pm on friday`（毎週金曜19時以降）から `after 7pm every day`（毎日19時以降）に変更
- 依存関係の更新をより早く検知し、セキュリティパッチの適用を迅速化

## Test plan
- [ ] マージ後、翌日のRenovate実行でPRが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)