### PR TITLE
feat: iloc-inc内のreusable workflowをSHA pin対象外にする

### DIFF
--- a/default.json
+++ b/default.json
@@ -23,6 +23,12 @@
     {
       "matchPackagePatterns": ["^@?aws-sdk", "^github\\.com/aws/aws-sdk-go-v2"],
       "groupName": "aws-sdk packages"
+    },
+    {
+      "description": "iloc-inc内のreusable workflow参照はSHA pinしない（private repo間のSHA pinはstartup_failureを引き起こすため）",
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": ["^iloc-inc/"],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
## 概要

iloc-inc内のreusable workflow参照（例: \`iloc-inc/company-ai-strategy/.github/workflows/cleanup-caches.yml@main\`）をSHA pinの対象外にします。

## 背景

iloc-inc/company-ai-strategy#170 で追加した reusable workflow を各リポジトリから呼び出す cleanup-caches.yml を整備したところ、Renovateが \`@main\` を SHA に置換するPRを自動マージし、その結果 **\`startup_failure\` で workflow が起動できない** 事象が発生しました。

実例:
- iloc-inc/company-site#134 (Renovateによる SHA pin PR)
- 結果: https://github.com/iloc-inc/company-site/actions/runs/25821611049 → startup_failure
- security-infra も同パターンで失敗

private repo 間で reusable workflow を SHA 参照すると、GitHub Actions の cross-repo アクセス制御の挙動上、起動に失敗するケースがあります。

## 設計判断

サプライチェーン攻撃対策としての SHA pin は **外部 action**（actions/checkout など）に対する防御策。**自分たちで管理する iloc-inc 内 private repo 間** では:

- 改ざんリスクは内部統制で担保
- SHA pin による startup_failure リスクの方が運用上の損失が大きい

→ iloc-inc/* に限り pinDigests を無効化

## 変更内容

\`default.json\` に以下の packageRule を追加:

\`\`\`json
{
  "matchManagers": ["github-actions"],
  "matchPackagePatterns": ["^iloc-inc/"],
  "pinDigests": false
}
\`\`\`

## マージ後の対応

各リポジトリでSHA pin済みの reusable workflow ref を \`@main\` に戻すPRを順次作成予定:

- company-site
- security-infra

## テストプラン

- [ ] マージ後、Renovateが iloc-inc/* に対する SHA pin PR を新規作成しないことを確認
- [ ] 後続PRで \`@main\` に戻したあと、cleanup workflow が正常起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)