### PR TITLE
chore: Renovate スケジュールを月次バッチ化（CVE は即時）

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["after 7pm every day"],
+  "schedule": ["before 3am on the first day of the month"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "dependencyDashboardApproval": false,
@@ -11,7 +11,8 @@
   "pinDigests": true,
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"]
+    "labels": ["security"],
+    "schedule": ["at any time"]
   },
   "hostRules": [
     {


### PR DESCRIPTION
## Summary

Renovate PR の発射頻度を **毎日 → 月1（1日 AM 3時 JST）** に変更。
セキュリティ更新だけは schedule を無視して即時 PR 化することで、コスト削減と CVE 対応速度を両立する。

## Why

GitHub Actions の課金が膨らんでいる主因が **Renovate の日次 PR**（5月実績: 9リポで 103 PR / 月、CI run 約 300回相当）。
通常の version bump はビジネス上の緊急性がないため、月初にまとめてレビューすればコストを大幅削減できる。
ただし CVE / 脆弱性 fix は遅延させたくないので、`vulnerabilityAlerts.schedule: ["at any time"]` で schedule をバイパスさせる。

## Changes

`default.json`:

\`\`\`diff
-  "schedule": ["after 7pm every day"],
+  "schedule": ["before 3am on the first day of the month"],
...
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"]
+    "labels": ["security"],
+    "schedule": ["at any time"]
   },
\`\`\`

## Expected Impact

| 項目 | Before | After |
|---|---:|---:|
| Renovate PR数/月 (9リポ合計) | ~103 | **~20-30** |
| CI run 数/月 (Renovate由来) | ~309 | **~60-90** |
| 想定コスト削減 | - | **70-80%** |

`go.json` の `groupName: "Go dependencies"` で各リポの gomod 更新は既に1 PRにバッチ済みなので、上記想定。

## Notes

- 全 iloc-inc リポ (kabu-station-feeder, martify, edinet-feeder, jpx-feeder, go-common, company-site, company-ai-strategy, infra, security-infra) が本 preset を extends しているため、本 PR マージで全リポに即時反映される。
- 月初に PR がまとまって発射されるため、その日に Dependency Dashboard を見てまとめてレビューする運用イメージ。
- CVE 即時化の挙動確認は、Renovate の `vulnerabilityAlerts` ドキュメント参照: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts

## Test plan
- [ ] マージ後、対象リポの Dependency Dashboard を確認して新規 PR が翌月1日まで出ないことを確認
- [ ] GitHub の Dependabot security alert を擬似的に発火させ、Renovate が即時 PR を作成するか確認（できれば）

🤖 Generated with [Claude Code](https://claude.com/claude-code)