### PR TITLE
chore: 参照0件の不要な Renovate 設定を削除

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,11 +19,5 @@
       "matchHost": "github.com",
       "hostType": "go"
     }
-  ],
-  "packageRules": [
-    {
-      "matchPackagePatterns": ["^@?aws-sdk", "^github\\.com/aws/aws-sdk-go-v2"],
-      "groupName": "aws-sdk packages"
-    }
   ]
 }

--- a/go.json
+++ b/go.json
@@ -62,10 +62,6 @@
       "groupName": "Go dependencies"
     },
     {
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["patch"]
-    },
-    {
       "matchManagers": ["regex"],
       "matchPackageNames": ["golangci/golangci-lint"],
       "groupName": "golangci-lint dependencies"

--- a/hugo.json
+++ b/hugo.json
@@ -3,28 +3,10 @@
 
   "regexManagers": [
     {
-      "description": "Netlify の HUGO_VERSION",
-      "fileMatch": ["^netlify\\.toml$"],
-      "matchStrings": [
-        "HUGO_VERSION\\s*=\\s*\"?(?<currentValue>\\d+\\.\\d+\\.\\d+)\"?"
-      ],
-      "depNameTemplate": "gohugoio/hugo",
-      "datasourceTemplate": "github-releases"
-    },
-    {
       "description": "GitHub Actions: actions-hugo の hugo-version 入力",
       "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
       "matchStrings": [
         "hugo-version:\\s*\"?v?(?<currentValue>\\d+\\.\\d+\\.\\d+)\"?"
-      ],
-      "depNameTemplate": "gohugoio/hugo",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "description": "Docker/Compose: klakegg/gohugoio のタグから数値部だけ更新",
-      "fileMatch": ["(^|/)Dockerfile$", "^docker-compose\\.ya?ml$"],
-      "matchStrings": [
-        "(?:klakegg|gohugoio)/hugo:(?<currentValue>\\d+(?:\\.\\d+){1,2})(?:[\\w\\-]*)"
       ],
       "depNameTemplate": "gohugoio/hugo",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
## 概要

不要コード監査の結果、参照0件で実害もない以下4つの設定を削除します。

| ファイル | 削除内容 | 根拠 |
|---------|---------|------|
| `hugo.json` | netlify.toml 用 regexManager | 全消費リポに `netlify.toml` 不在（Hugoは peaceiris/actions-hugo + GitHub Actions env で管理） |
| `hugo.json` | klakegg/gohugoio Docker image 用 regexManager | 全消費リポの Dockerfile/docker-compose で `klakegg/gohugoio/hugo` 参照0件 |
| `default.json` | aws-sdk packages の packageRule | `default` を extends するリポにJSプロジェクト無し（`@aws-sdk` 参照0件）。Go版（`aws-sdk-go-v2`）も `go.json` の `Go dependencies` グループに後勝ちで吸収され、ルール自体が実質無効化 |
| `go.json` | 空の patch ルール | `matchManagers: gomod, matchUpdateTypes: patch` のみで `groupName`/`automerge`/`labels` 等の指定無し → 何も上書きしないデッドルール |

## 検証

- `python3 -c "import json; json.load(...)"` で4ファイル全て JSON 有効
- 全リポ（company-site / expense-automation / infra / kabu-station-feeder / martify / security-infra / go-common / jpx-feeder / edinet-feeder）への `find -name netlify.toml`、Dockerfile/docker-compose の `klakegg|gohugoio` grep、`package.json` の `@aws-sdk` grep いずれも0件

## 動機

不要コード監査（[claude-code セッション内](#)）の Wave 1 第1弾。リファクタの前段として、明らかに参照されていない設定を削除して見通しを良くする。

## 影響範囲

- 既存の Renovate PR の挙動: 変化なし
  - aws-sdk-go-v2 は今後も `go.json` の `Go dependencies` グループに入る（後勝ちの挙動が消えるだけで結果は同じ）
- 将来 JS プロジェクトが追加された場合、`@aws-sdk` のグルーピングは個別に再定義が必要（ただし現状そのような計画なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)