### PR TITLE
fix: private Goモジュールのtidy向けにgithub.com hostRuleへPATを追加

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,7 +17,8 @@
   "hostRules": [
     {
       "matchHost": "github.com",
-      "hostType": "go"
+      "hostType": "go",
+      "token": "{{ secrets.PAT_TOKEN }}"
     }
   ]
 }


### PR DESCRIPTION
## 背景

Renovate が go-common 等の **private モジュール** 更新 PR を作る際、内部で `go mod tidy` を実行する。しかし `default.json` の github.com hostRule に**トークンが無い**ため private repo をクローンできず、`go.sum` が不完全な状態で PR が作られていた。

結果、consuming リポジトリ側 CI（`go build` / `go test` は readonly モード）が **`missing go.sum entry`** で落ち、毎回ローカルで `go mod tidy` し直してプッシュする手間が発生していた。

## 変更

github.com hostRule に `PAT_TOKEN` を渡し、Renovate の tidy サブプロセスから private モジュールを解決できるようにする。

```diff
   "hostRules": [
     {
       "matchHost": "github.com",
-      "hostType": "go"
+      "hostType": "go",
+      "token": "{{ secrets.PAT_TOKEN }}"
     }
   ]
```

各リポジトリの CI（例: `edinet-feeder/.github/workflows/ci.yml`）が private モジュールアクセスに使っている `PAT_TOKEN` と同じ方式に揃える。

## ⚠️ マージ前/後に必要な作業

- **Mend 側で Renovate secret `PAT_TOKEN` を登録**する必要がある（org または対象リポジトリ単位）。値は go-common に read 権限のある PAT。
- 未登録のままだと `{{ secrets.PAT_TOKEN }}` が解決されず効果が出ない。

## 確認

- `jq . default.json` 構文チェック OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)