### PR TITLE
fix: hostRuleの参照secret名をGO_COMMON_TOKENに修正

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,7 +18,7 @@
     {
       "matchHost": "github.com",
       "hostType": "go",
-      "token": "{{ secrets.PAT_TOKEN }}"
+      "token": "{{ secrets.GO_COMMON_TOKEN }}"
     }
   ]
 }


### PR DESCRIPTION
## 背景

#35 で github.com の go hostRule に `{{ secrets.PAT_TOKEN }}` を追加したが、Mend org に実在する secret 名は **`GO_COMMON_TOKEN`** であり `PAT_TOKEN` は未登録だった。そのため Renovate が以下のエラーで停止していた:

```
Error type: 'Unknown secrets name'
Message: 'The following secrets name was not found in config: PAT_TOKEN'
```

Mend org には既に以下が登録済みであることを確認:
- Credentials secret: `GO_COMMON_TOKEN`（go-common 用 PAT）
- Host Rule: `https://github.com/iloc-inc/go-common` → Token / `GO_COMMON_TOKEN`

## 変更

参照を実在の secret に合わせる。

```diff
   "hostRules": [
     {
       "matchHost": "github.com",
       "hostType": "go",
-      "token": "{{ secrets.PAT_TOKEN }}"
+      "token": "{{ secrets.GO_COMMON_TOKEN }}"
     }
   ]
```

`matchHost: github.com` × `hostType: go` のホスト全体ルールにすることで、go mod tidy 実行時に iloc-inc 配下の private モジュールを Go ツールチェーンから解決できる（既存の go-common URL ピンポイントの Host Rule より tidy 向けに適切）。

## 確認

- `jq . default.json` OK
- マージ後、jpx-feeder 等で Renovate を再実行し `Unknown secrets name` が解消すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)